### PR TITLE
Allow for more than 1000 device results and return empty _meta for speed

### DIFF
--- a/d42_ansible_dynamic_inventory.py
+++ b/d42_ansible_dynamic_inventory.py
@@ -33,14 +33,14 @@ class Inventory(object):
     # Example inventory for testing.
     def inventory(self):
         rest = REST(conf)
-        rest_res = json.loads(rest.get_devices())
+        returned_devices = rest.get_devices()
 
         if conf.GROUP_BY not in available_groups:
             print '\n[!] ERROR: wrong grouping name'
             sys.exit()
 
         ansible = Ansible(conf)
-        return ansible.get_grouping(rest_res)
+        return ansible.get_grouping(returned_devices)
 
     # Empty inventory for testing.
     def empty_inventory(self):


### PR DESCRIPTION
The script as is will only work on the first 1000 devices, so this deals with pagination.

The script as is also doesn't seem to return the results in the ansible specified format. This adds the hosts directory under the group name directory.

Lastly, when I got it working with my 7000 hosts, it was very slow so I added an empty _meta response to speed it up (since the --hosts call doesn't seem to be implemented yet).