### PR TITLE
Correct source url for requirements.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ touch requirements.yml
 * add the following to your file and save it
 ```bash
 collections:
-- name: device42.d42
-version: 1.0.0
-source: https://galaxy.ansible.com/device42/d42
+    - name: device42.d42
+      version: 1.0.0
+      source: https://galaxy.ansible.com
 ```
 
 * Install the Ansible collection by running command

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ touch requirements.yml
 ```bash
 collections:
     - name: device42.d42
-      version: 1.0.0
+      version: 1.1.0
       source: https://galaxy.ansible.com
 ```
 


### PR DESCRIPTION
The installation of the collection fails, if a complete url (e.g. 'https://galaxy.ansible.com/device42/d42') is provided:

```
ansible-galaxy collection install -r ./collections/requirements.yml
Process install dependency map
ERROR! Failed to parse Galaxy response from 'https://galaxy.ansible.com/device42/d42/api' as JSON:
[...]
```

Greetings