### PR TITLE
D42-30614 - Ansible plugin may not return correct value for boolean type properties

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.9"


### PR DESCRIPTION
Added runtime.yml with requires_ansible settings since it is required in order to upload to Galaxy.